### PR TITLE
feat: Add copy to clipboard button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "zatsudan-gacha",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "autoprefixer": "^10.4.21",
         "next": "^14.2.32",
+        "next-themes": "^0.4.6",
         "react": "^18",
         "react-dom": "^18"
       },
@@ -423,6 +425,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -9068,6 +9079,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "autoprefixer": "^10.4.21",
     "next": "^14.2.32",
     "next-themes": "^0.4.6",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { FavoritesList } from '@/components/FavoritesList';
 import { Tabs } from '@/components/Tabs';
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline';
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid';
-import { ClockIcon, StarIcon } from '@heroicons/react/24/outline';
+import { ClockIcon, StarIcon, ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
 
 
 export default function Home() {
@@ -23,6 +23,7 @@ export default function Home() {
     const [digDeeperResults, setDigDeeperResults] = useState<React.ReactNode>(null);
     const { history, addHistory } = useHistory();
     const { favorites, toggleFavorite } = useFavorites();
+    const [isCopied, setIsCopied] = useState(false);
 
     const resetGeminiFeatures = () => {
         setDigDeeperResults(null);
@@ -79,17 +80,31 @@ export default function Home() {
             <div className="text-center relative">
                 <span className="inline-block bg-indigo-100 text-indigo-800 dark:bg-indigo-900/50 dark:text-indigo-300 text-sm font-semibold px-3 py-1 rounded-full mb-3">{categoryName}</span>
                 <p className="text-2xl md:text-3xl font-bold text-indigo-600 dark:text-indigo-400">{theme}</p>
-                <button
-                    onClick={() => toggleFavorite(theme)}
-                    className="absolute top-1/2 -translate-y-1/2 right-0 md:-right-12 p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
-                    aria-label="お気に入りに追加/削除"
-                >
-                    {favorites.includes(theme) ? (
-                        <StarIconSolid className="h-6 w-6 text-yellow-400" />
-                    ) : (
-                        <StarIconOutline className="h-6 w-6 text-gray-400" />
-                    )}
-                </button>
+                <div className="absolute top-1/2 -translate-y-1/2 right-0 md:-right-12 flex items-center space-x-2">
+                    <button
+                        onClick={() => handleCopy(theme)}
+                        className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+                        aria-label="コピーする"
+                    >
+                        {isCopied ? (
+                            <CheckIcon className="h-6 w-6 text-green-500" />
+                        ) : (
+                            <ClipboardIcon className="h-6 w-6 text-gray-400" />
+                        )}
+                    </button>
+                    <button
+                        onClick={() => toggleFavorite(theme)}
+                        className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-600"
+                        aria-label="お気に入りに追加/削除"
+                    >
+                        {favorites.includes(theme) ? (
+                            <StarIconSolid className="h-6 w-6 text-yellow-400" />
+                        ) : (
+                            <StarIconOutline className="h-6 w-6 text-gray-400" />
+                        )}
+                    </button>
+                </div>
+                {isCopied && <p className="text-sm text-green-600 dark:text-green-400 mt-2">コピーしました！</p>}
             </div>
         );
         setShowGeminiArea(true);
@@ -99,6 +114,17 @@ export default function Home() {
     const handleSelectTheme = (theme: string) => {
         updateTheme(theme);
         window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleCopy = (text: string) => {
+        navigator.clipboard.writeText(text).then(() => {
+            setIsCopied(true);
+            setTimeout(() => {
+                setIsCopied(false);
+            }, 2000);
+        }).catch(err => {
+            console.error('Failed to copy text: ', err);
+        });
     };
 
     const getDeeperQuestions = async () => {


### PR DESCRIPTION
This commit adds a button to copy the generated theme to the clipboard.

- A "copy" icon button is added next to the theme text.
- When clicked, the theme text is copied to the user's clipboard.
- The button provides visual feedback by changing to a "check" icon and showing a "Copied!" message for 2 seconds.
- Added `@heroicons/react` as a dependency.