### PR TITLE
Fix: Add metadataBase to generate absolute URLs for share images

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,10 +8,12 @@ const inter = Inter({ subsets: ["latin"], variable: '--font-inter' });
 const notoSansJp = Noto_Sans_JP({ subsets: ["latin"], weight: ["400", "700"], variable: '--font-noto-sans-jp' });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://zatsudan-gacha.app/"),
   title: "雑談テーマガチャ",
   description: "リモートでも、雑談でつながろう。",
   icons: {
     icon: "/favicon.png",
+    shortcut: "/favicon.png",
     apple: "/favicon.png",
   },
   openGraph: {


### PR DESCRIPTION
This change adds `metadataBase` to the Next.js metadata configuration in `src/app/layout.tsx`. This ensures that absolute URLs are generated for Open Graph and Twitter share images, which is required by social media platforms.

Additionally, the `icons` metadata has been updated to include a `shortcut` icon to improve favicon handling by browsers.