### PR TITLE
The favicon was not being displayed because a manual `<head>` tag in …

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, Noto_Sans_JP } from "next/font/google";
+import Script from "next/script";
 import { Providers } from "./providers";
 import { DomainRedirect } from "@/components/DomainRedirect";
 import "./globals.css";
@@ -58,16 +59,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
-      <head>
-        <script 
-          async 
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7296906013994885"
-          crossOrigin="anonymous"
-        />
-      </head>
       <body className={`${inter.variable} ${notoSansJp.variable} font-sans`}>
         <DomainRedirect />
         <Providers>{children}</Providers>
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7296906013994885"
+          crossOrigin="anonymous"
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
…`src/app/layout.tsx` was overriding the head generated by Next.js's metadata API.

This commit resolves the issue by:
- Removing the manual `<head>` tag from the root layout.
- Importing the `Script` component from `next/script`.
- Using the `Script` component to load the Google AdSense script, which is the recommended approach in Next.js.

This allows Next.js to correctly manage the document head, ensuring the favicon defined in the metadata is properly rendered, while preserving the AdSense functionality.