### PR TITLE
feat: Implement Oshikatsu Profile Maker

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  images: {
+    unoptimized: true,
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@types/html2canvas": "^1.0.0",
     "autoprefixer": "^10.4.21",
     "firebase": "^12.1.0",
+    "html2canvas": "^1.4.1",
     "next": "^14.2.32",
     "next-themes": "^0.4.6",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@18.3.1)
+      '@types/html2canvas':
+        specifier: ^1.0.0
+        version: 1.0.0
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
       firebase:
         specifier: ^12.1.0
         version: 12.1.0
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       next:
         specifier: ^14.2.32
         version: 14.2.32(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -716,6 +722,10 @@ packages:
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
 
+  '@types/html2canvas@1.0.0':
+    resolution: {integrity: sha512-BJpVf+FIN9UERmzhbtUgpXj6XBZpG67FMgBLLoj9HZKd9XifcCpSV+UnFcwTZfEyun4U/KmCrrVOG7829L589w==}
+    deprecated: This is a stub types definition. html2canvas provides its own type definitions, so you do not need this installed.
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1082,6 +1092,10 @@ packages:
   bare-events@2.6.1:
     resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1386,6 +1400,9 @@ packages:
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -2113,6 +2130,10 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -3683,6 +3704,9 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -3848,6 +3872,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -4797,6 +4824,10 @@ snapshots:
 
   '@types/caseless@0.12.5': {}
 
+  '@types/html2canvas@1.0.0':
+    dependencies:
+      html2canvas: 1.4.1
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -5156,6 +5187,8 @@ snapshots:
   bare-events@2.6.1:
     optional: true
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   basic-auth-connect@1.1.0:
@@ -5511,6 +5544,10 @@ snapshots:
       which: 2.0.2
 
   crypto-random-string@2.0.0: {}
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   cssesc@3.0.0: {}
 
@@ -6634,6 +6671,11 @@ snapshots:
   heap-js@2.6.0: {}
 
   highlight.js@10.7.3: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   http-cache-semantics@4.2.0:
     optional: true
@@ -8388,6 +8430,10 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -8597,6 +8643,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@8.3.2: {}
 

--- a/src/app/profile-maker/page.tsx
+++ b/src/app/profile-maker/page.tsx
@@ -12,6 +12,7 @@ export default function ProfileMakerPage() {
     name: 'すごい推し',
     group: '次元を超えた存在',
     color: '#a855f7', // purple-500
+    image: '',
     likes: ['顔', '声', '全部'],
     episode: '伝説のライブでのパフォーマンスに感動した',
     favoriteVisual: 'デビュー当時の初々しいビジュアル',
@@ -56,18 +57,29 @@ export default function ProfileMakerPage() {
                 <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">
                   プレビュー
                 </h2>
-                <div className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-1 rounded-lg">
-                  {(['simple', 'pop', 'cool'] as Template[]).map(t => (
+                <div className="flex flex-wrap gap-1 bg-gray-200 dark:bg-gray-700 p-1 rounded-lg">
+                  {([
+                    { key: 'simple', label: 'シンプル' },
+                    { key: 'pop', label: 'ポップ' },
+                    { key: 'cool', label: 'クール' },
+                    { key: 'elegant', label: 'エレガント' },
+                    { key: 'kawaii', label: 'かわいい' },
+                    { key: 'vintage', label: 'ヴィンテージ' },
+                    { key: 'neon', label: 'ネオン' },
+                    { key: 'dreamy', label: 'ドリーミー' },
+                    { key: 'retro', label: 'レトロ' },
+                    { key: 'minimal', label: 'ミニマル' }
+                  ] as { key: Template; label: string }[]).map(({ key, label }) => (
                     <button
-                      key={t}
-                      onClick={() => setTemplate(t)}
-                      className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
-                        template === t
+                      key={key}
+                      onClick={() => setTemplate(key)}
+                      className={`px-2 py-1 text-xs font-medium rounded-md transition-colors ${
+                        template === key
                           ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow'
                           : 'text-gray-600 dark:text-gray-300 hover:bg-gray-300/50 dark:hover:bg-gray-600/50'
                       }`}
                     >
-                      {t.charAt(0).toUpperCase() + t.slice(1)}
+                      {label}
                     </button>
                   ))}
                 </div>

--- a/src/app/profile-maker/page.tsx
+++ b/src/app/profile-maker/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from 'react';
+import { ProfileForm } from '@/components/profile-maker/ProfileForm';
+import { ProfileCardPreview } from '@/components/profile-maker/ProfileCardPreview';
+import { ActionButtons } from '@/components/profile-maker/ActionButtons';
+import { ThemeToggleButton } from '@/components/ThemeToggleButton';
+import { ProfileState, Template } from '@/types';
+
+export default function ProfileMakerPage() {
+  const [profile, setProfile] = useState<ProfileState>({
+    name: 'すごい推し',
+    group: '次元を超えた存在',
+    color: '#a855f7', // purple-500
+    likes: ['顔', '声', '全部'],
+    episode: '伝説のライブでのパフォーマンスに感動した',
+    favoriteVisual: 'デビュー当時の初々しいビジュアル',
+    favoriteQuote: '「諦めたらそこで試合終了ですよ」',
+    customTags: ['#存在が尊い', '#歩く芸術'],
+    pairName: '伝説のコンビ',
+    pairEpisode: '二人にしか出せない空気感が好き',
+    fanHistory: 'デビュー当時から',
+    title: '顔面国宝',
+  });
+
+  const [template, setTemplate] = useState<Template>('simple');
+
+  return (
+    <div className="bg-slate-100 dark:bg-slate-900 min-h-screen p-4 sm:p-8 font-sans transition-colors duration-300">
+      <div className="max-w-7xl mx-auto">
+        <header className="flex justify-between items-center mb-8">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold text-gray-800 dark:text-gray-100">
+              推し活プロフィールメーカー
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-2">
+              君の「好き」をカードにのせて、世界に届けよう。
+            </p>
+          </div>
+          <ThemeToggleButton />
+        </header>
+
+        <main className="grid grid-cols-1 lg:grid-cols-5 gap-8">
+          {/* Left: Form Area */}
+          <div className="lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-2xl shadow-lg">
+            <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-gray-200">
+              プロフィールを入力
+            </h2>
+            <ProfileForm profile={profile} setProfile={setProfile} />
+          </div>
+
+          {/* Right: Preview & Control Area */}
+          <div className="lg:col-span-3">
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-2xl shadow-lg">
+              <div className="flex justify-between items-center mb-6">
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200">
+                  プレビュー
+                </h2>
+                <div className="flex space-x-1 bg-gray-200 dark:bg-gray-700 p-1 rounded-lg">
+                  {(['simple', 'pop', 'cool'] as Template[]).map(t => (
+                    <button
+                      key={t}
+                      onClick={() => setTemplate(t)}
+                      className={`px-3 py-1 text-sm font-medium rounded-md transition-colors ${
+                        template === t
+                          ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow'
+                          : 'text-gray-600 dark:text-gray-300 hover:bg-gray-300/50 dark:hover:bg-gray-600/50'
+                      }`}
+                    >
+                      {t.charAt(0).toUpperCase() + t.slice(1)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <ProfileCardPreview profile={profile} template={template} />
+            </div>
+
+            <div className="bg-white dark:bg-gray-800 p-6 rounded-2xl shadow-lg mt-8">
+               <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-gray-200">
+                完成したら…
+              </h2>
+              <ActionButtons profileName={profile.name} />
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile-maker/ActionButtons.tsx
+++ b/src/components/profile-maker/ActionButtons.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import html2canvas from 'html2canvas';
+import { trackEvent } from '@/lib/firebase';
+import { useState } from 'react';
+
+interface ActionButtonsProps {
+  profileName: string; // Needed for dynamic filenames and share text
+}
+
+const XIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor" {...props}>
+        <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z" />
+    </svg>
+);
+
+export const ActionButtons: React.FC<ActionButtonsProps> = ({ profileName }) => {
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const handleGenerateImage = async () => {
+    const cardElement = document.getElementById('profile-card');
+    if (!cardElement) {
+      console.error("Card element not found!");
+      return;
+    }
+
+    setIsGenerating(true);
+    try {
+      trackEvent('generate_card_start', { name: profileName });
+      const canvas = await html2canvas(cardElement, {
+        useCORS: true,
+        scale: 2, // Higher resolution for better quality
+        backgroundColor: null, // Use element's background
+      });
+
+      const link = document.createElement('a');
+      const safeFilename = profileName.replace(/[^a-z0-9_]/gi, '_').toLowerCase();
+      link.download = `${safeFilename}_oshi_profile.png`;
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+      trackEvent('generate_card_success', { name: profileName });
+
+    } catch (error) {
+      console.error("Error generating image:", error);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      trackEvent('generate_card_error', { name: profileName, error: errorMessage });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const handleShareToX = () => {
+    const shareText = `見てみて！私の推し「${profileName}」のプロフィールカード作ったよ！\nみんなも作ってみよう！\n\n#推し活プロフィールメーカー\n#${profileName.replace(/\s/g, '_')}`;
+    const appUrl = 'https://zatsudan-gacha.web.app'; // Replace with the actual app URL if it's dynamic
+    const twitterIntentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(appUrl)}`;
+
+    window.open(twitterIntentUrl, '_blank');
+    trackEvent('share_to_x_click', { name: profileName });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="p-4 bg-indigo-50 dark:bg-indigo-900/30 rounded-lg text-center border border-indigo-200 dark:border-indigo-700">
+        <p className="text-sm text-indigo-800 dark:text-indigo-200">
+          <span className="font-bold">①</span> 下のボタンから画像をダウンロード<br/>
+          <span className="font-bold">②</span> X（旧Twitter）で画像を添付して投稿！
+        </p>
+      </div>
+      <button
+        onClick={handleGenerateImage}
+        disabled={isGenerating}
+        className="w-full bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 text-white font-bold py-4 px-6 rounded-lg text-xl transition-all duration-300 shadow-lg hover:shadow-xl disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center"
+      >
+        {isGenerating ? '生成中...' : '画像をダウンロード'}
+      </button>
+      <button
+        onClick={handleShareToX}
+        className="w-full bg-black dark:bg-white text-white dark:text-black font-bold py-3 px-6 rounded-lg text-lg transition-all duration-200 flex items-center justify-center space-x-2 hover:bg-gray-800 dark:hover:bg-gray-200"
+      >
+        <XIcon className="h-5 w-5" />
+        <span>Xでシェアする</span>
+      </button>
+    </div>
+  );
+};

--- a/src/components/profile-maker/ProfileCardPreview.tsx
+++ b/src/components/profile-maker/ProfileCardPreview.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { ProfileState, Template } from "@/types";
+
+interface ProfileCardPreviewProps {
+  profile: ProfileState;
+  template: Template;
+}
+
+// Helper component for card sections
+const CardSection = ({ title, children, className = '' }: { title: string; children: React.ReactNode; className?: string; }) => (
+  <div className={className}>
+    <h3 className="text-sm font-bold uppercase tracking-wider mb-2">{title}</h3>
+    <div>
+      {children}
+    </div>
+  </div>
+);
+
+export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile, template }) => {
+  const {
+    name, group, color, likes, episode, favoriteQuote, customTags, title, fanHistory
+  } = profile;
+
+  // --- Template Styles ---
+  const templates = {
+    simple: {
+      card: 'p-4 sm:p-8 bg-white dark:bg-gray-800 rounded-lg shadow-lg font-sans text-gray-800 dark:text-gray-200',
+      header: 'border-b-2',
+      name: 'text-5xl font-bold text-gray-900 dark:text-white',
+      group: 'text-base text-gray-500 dark:text-gray-400',
+      titleContainer: 'p-3 text-center rounded-lg',
+      titleText: 'font-bold text-xl',
+      sectionTitle: 'text-gray-500 dark:text-gray-400',
+      tag: 'px-3 py-1 text-sm font-medium rounded-full',
+      quote: 'text-lg italic',
+      footer: 'border-t border-gray-200 dark:border-gray-700',
+      hashtag: 'font-bold',
+    },
+    pop: {
+      card: 'p-4 sm:p-8 bg-yellow-50 dark:bg-yellow-900/30 rounded-3xl shadow-xl font-bold font-sans border-4 border-black text-black dark:text-white',
+      header: 'border-b-4 border-black dark:border-white',
+      name: 'text-6xl font-black tracking-tighter text-black dark:text-white',
+      group: 'text-lg font-bold text-gray-700 dark:text-gray-300',
+      titleContainer: 'p-3 text-center rounded-2xl border-2 border-black dark:border-white rotate-6',
+      titleText: 'font-black text-2xl',
+      sectionTitle: 'text-black dark:text-white',
+      tag: 'px-4 py-1.5 text-base font-bold rounded-full border-2 border-black dark:border-white shadow-[4px_4px_0_0_#000]',
+      quote: 'text-xl font-bold italic bg-white/50 dark:bg-black/20 p-3 rounded-lg',
+      footer: 'border-t-4 border-black dark:border-white',
+      hashtag: 'font-black text-lg p-2 rounded-lg',
+    },
+    cool: {
+      card: 'p-4 sm:p-8 bg-gray-900 rounded-lg shadow-2xl font-mono text-gray-100 border border-gray-700',
+      header: 'border-b border-gray-700',
+      name: 'text-5xl font-bold text-white tracking-widest',
+      group: 'text-base text-cyan-400',
+      titleContainer: 'p-2 text-center border border-cyan-400',
+      titleText: 'font-bold text-xl text-cyan-400',
+      sectionTitle: 'text-cyan-400',
+      tag: 'px-3 py-1 text-sm font-medium rounded-sm bg-cyan-400/10 text-cyan-300 border border-cyan-400/30',
+      quote: 'text-lg italic text-gray-300',
+      footer: 'border-t border-gray-700',
+      hashtag: 'font-bold text-cyan-400',
+    }
+  };
+
+  const s = templates[template];
+
+  // --- Dynamic Styles ---
+  const accentStyle = template === 'cool' ? { borderColor: color, color: color } : { borderColor: color };
+  const accentTextStyle = { color: color };
+  const accentBgStyle = template === 'pop' ? { backgroundColor: color, color: 'white' } : { backgroundColor: `${color}20` };
+  const accentTagStyle = template === 'pop'
+    ? { backgroundColor: color, color: 'white', boxShadow: `2px 2px 0 0 #000` }
+    : { backgroundColor: `${color}30`, color: color };
+
+  return (
+    <div id="profile-card" className={`${s.card} aspect-[1.91/1] flex flex-col transition-all duration-300`}>
+      {/* Header */}
+      <header className={`flex items-start pb-2 sm:pb-4 ${s.header}`} style={accentStyle}>
+        <div className="flex-grow">
+          <p className={`${s.group} text-sm sm:text-base`}>{group || ' '}</p>
+          <h2 className={`${s.name} text-3xl sm:text-4xl md:text-5xl`}>{name || '推しの名前'}</h2>
+        </div>
+        {title && (
+          <div className={`${s.titleContainer} ml-2`}>
+            <p className={`${s.titleText} text-base sm:text-xl`} style={template === 'pop' ? {textShadow: '2px 2px 0 #000'} : {}}>{title}</p>
+            {template !== 'pop' && <p className="text-xs uppercase tracking-wider" style={accentTextStyle}>- Title -</p>}
+          </div>
+        )}
+      </header>
+
+      {/* Body */}
+      <main className="flex-grow mt-3 sm:mt-6 grid grid-cols-1 md:grid-cols-5 gap-x-4 md:gap-x-8">
+        <div className="md:col-span-3 space-y-2 sm:space-y-4">
+          <CardSection title="好きなところ" className={s.sectionTitle}>
+            <div className="flex flex-wrap gap-1 sm:gap-2">
+              {likes.length > 0 ? likes.map(like => (
+                <span key={like} className={`${s.tag} text-xs sm:text-sm`} style={accentTagStyle}>
+                  {like}
+                </span>
+              )) : <p className="text-gray-400 text-sm">（未入力）</p>}
+            </div>
+          </CardSection>
+
+          <CardSection title="心に残る言葉・歌詞" className={`${s.sectionTitle} mt-2 sm:mt-4`}>
+            <p className={`${s.quote} text-sm sm:text-lg`}>
+              {favoriteQuote ? `“${favoriteQuote}”` : <span className="text-gray-400 text-sm">（未入力）</span>}
+            </p>
+          </CardSection>
+        </div>
+        <div className="md:col-span-2 space-y-2 sm:space-y-4 md:border-l border-gray-200 dark:border-gray-700 md:pl-4 lg:pl-8 mt-2 md:mt-0">
+           <CardSection title="出会いのきっかけ" className={s.sectionTitle}>
+            <p className="text-sm sm:text-base">{episode || <span className="text-gray-400 text-sm">（未入力）</span>}</p>
+          </CardSection>
+          <CardSection title="ファン歴" className={s.sectionTitle}>
+            <p className="text-sm sm:text-base">{fanHistory || <span className="text-gray-400 text-sm">（未入力）</span>}</p>
+          </CardSection>
+        </div>
+      </main>
+
+      {/* Footer */}
+      <footer className={`mt-auto pt-2 sm:pt-4 ${s.footer}`}>
+        <div className="flex justify-between items-center">
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+                {customTags.length > 0 ? customTags.map(tag => (
+                  <span key={tag} className="text-sm text-gray-500 dark:text-gray-400">
+                    {tag.startsWith('#') ? tag : `#${tag}`}
+                  </span>
+                )) : <div/>}
+            </div>
+            <p className={s.hashtag} style={accentTextStyle}>
+              #推し活プロフィールメーカー
+            </p>
+        </div>
+      </footer>
+    </div>
+  );
+};

--- a/src/components/profile-maker/ProfileCardPreview.tsx
+++ b/src/components/profile-maker/ProfileCardPreview.tsx
@@ -19,7 +19,7 @@ const CardSection = ({ title, children, className = '' }: { title: string; child
 
 export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile, template }) => {
   const {
-    name, group, color, likes, episode, favoriteQuote, customTags, title, fanHistory
+    name, group, color, image, likes, episode, favoriteQuote, customTags, title, fanHistory
   } = profile;
 
   // --- Template Styles ---
@@ -29,8 +29,8 @@ export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile,
       header: 'border-b-2',
       name: 'text-5xl font-bold text-gray-900 dark:text-white',
       group: 'text-base text-gray-500 dark:text-gray-400',
-      titleContainer: 'p-3 text-center rounded-lg',
-      titleText: 'font-bold text-xl',
+      titleContainer: 'p-3 text-center rounded-lg shadow-sm bg-white/50 dark:bg-gray-700/50',
+      titleText: 'font-bold text-xl text-gray-900 dark:text-white',
       sectionTitle: 'text-gray-500 dark:text-gray-400',
       tag: 'px-3 py-1 text-sm font-medium rounded-full',
       quote: 'text-lg italic',
@@ -42,8 +42,8 @@ export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile,
       header: 'border-b-4 border-black dark:border-white',
       name: 'text-6xl font-black tracking-tighter text-black dark:text-white',
       group: 'text-lg font-bold text-gray-700 dark:text-gray-300',
-      titleContainer: 'p-3 text-center rounded-2xl border-2 border-black dark:border-white rotate-6',
-      titleText: 'font-black text-2xl',
+      titleContainer: 'p-4 text-center rounded-2xl border-3 border-black dark:border-white rotate-3 bg-white dark:bg-gray-800 shadow-[4px_4px_0_0_#000] dark:shadow-[4px_4px_0_0_#fff]',
+      titleText: 'font-black text-xl text-black dark:text-white',
       sectionTitle: 'text-black dark:text-white',
       tag: 'px-4 py-1.5 text-base font-bold rounded-full border-2 border-black dark:border-white shadow-[4px_4px_0_0_#000]',
       quote: 'text-xl font-bold italic bg-white/50 dark:bg-black/20 p-3 rounded-lg',
@@ -55,13 +55,104 @@ export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile,
       header: 'border-b border-gray-700',
       name: 'text-5xl font-bold text-white tracking-widest',
       group: 'text-base text-cyan-400',
-      titleContainer: 'p-2 text-center border border-cyan-400',
+      titleContainer: 'p-3 text-center border border-cyan-400 bg-gray-800/80',
       titleText: 'font-bold text-xl text-cyan-400',
       sectionTitle: 'text-cyan-400',
       tag: 'px-3 py-1 text-sm font-medium rounded-sm bg-cyan-400/10 text-cyan-300 border border-cyan-400/30',
       quote: 'text-lg italic text-gray-300',
       footer: 'border-t border-gray-700',
       hashtag: 'font-bold text-cyan-400',
+    },
+    elegant: {
+      card: 'p-4 sm:p-8 bg-gradient-to-br from-purple-50 to-pink-50 dark:from-purple-900/30 dark:to-pink-900/30 rounded-2xl shadow-xl font-serif text-gray-800 dark:text-gray-200',
+      header: 'border-b border-purple-200 dark:border-purple-700',
+      name: 'text-5xl font-light text-purple-900 dark:text-purple-100 tracking-wide',
+      group: 'text-base text-purple-600 dark:text-purple-400 font-medium',
+      titleContainer: 'p-3 text-center rounded-xl bg-gradient-to-r from-purple-100 to-pink-100 dark:from-purple-800 dark:to-pink-800 border border-purple-200 dark:border-purple-600',
+      titleText: 'font-medium text-lg text-purple-900 dark:text-purple-100',
+      sectionTitle: 'text-purple-600 dark:text-purple-400',
+      tag: 'px-3 py-1 text-sm font-medium rounded-full bg-purple-100 dark:bg-purple-800 text-purple-800 dark:text-purple-200',
+      quote: 'text-lg italic text-purple-700 dark:text-purple-300',
+      footer: 'border-t border-purple-200 dark:border-purple-700',
+      hashtag: 'font-medium text-purple-600 dark:text-purple-400',
+    },
+    kawaii: {
+      card: 'p-4 sm:p-8 bg-pink-50 dark:bg-pink-900/20 rounded-3xl shadow-lg font-sans text-pink-900 dark:text-pink-100 border-2 border-pink-200 dark:border-pink-700',
+      header: 'border-b-2 border-pink-200 dark:border-pink-700',
+      name: 'text-5xl font-bold text-pink-600 dark:text-pink-300',
+      group: 'text-base text-pink-500 dark:text-pink-400',
+      titleContainer: 'p-3 text-center rounded-full bg-pink-100 dark:bg-pink-800 border-2 border-pink-300 dark:border-pink-600',
+      titleText: 'font-bold text-lg text-pink-700 dark:text-pink-200',
+      sectionTitle: 'text-pink-600 dark:text-pink-400',
+      tag: 'px-3 py-1.5 text-sm font-medium rounded-full bg-pink-200 dark:bg-pink-700 text-pink-800 dark:text-pink-200',
+      quote: 'text-lg text-pink-700 dark:text-pink-300',
+      footer: 'border-t-2 border-pink-200 dark:border-pink-700',
+      hashtag: 'font-bold text-pink-600 dark:text-pink-400',
+    },
+    vintage: {
+      card: 'p-4 sm:p-8 bg-amber-50 dark:bg-amber-900/20 rounded-lg shadow-lg font-serif text-amber-900 dark:text-amber-100 border border-amber-200 dark:border-amber-700',
+      header: 'border-b-2 border-amber-300 dark:border-amber-600',
+      name: 'text-5xl font-bold text-amber-800 dark:text-amber-200',
+      group: 'text-base text-amber-600 dark:text-amber-400',
+      titleContainer: 'p-3 text-center bg-amber-100 dark:bg-amber-800 border border-amber-300 dark:border-amber-600',
+      titleText: 'font-bold text-lg text-amber-800 dark:text-amber-200',
+      sectionTitle: 'text-amber-700 dark:text-amber-300',
+      tag: 'px-3 py-1 text-sm font-medium bg-amber-200 dark:bg-amber-700 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-600',
+      quote: 'text-lg italic text-amber-700 dark:text-amber-300',
+      footer: 'border-t-2 border-amber-300 dark:border-amber-600',
+      hashtag: 'font-bold text-amber-700 dark:text-amber-300',
+    },
+    neon: {
+      card: 'p-4 sm:p-8 bg-black rounded-xl shadow-2xl font-mono text-green-400 border border-green-500',
+      header: 'border-b border-green-500',
+      name: 'text-5xl font-bold text-green-400 drop-shadow-[0_0_10px_rgba(34,197,94,0.7)]',
+      group: 'text-base text-green-300',
+      titleContainer: 'p-3 text-center border border-green-500 bg-green-500/10 shadow-[0_0_15px_rgba(34,197,94,0.3)]',
+      titleText: 'font-bold text-lg text-green-400',
+      sectionTitle: 'text-green-300',
+      tag: 'px-3 py-1 text-sm font-medium bg-green-500/20 text-green-300 border border-green-500 shadow-[0_0_10px_rgba(34,197,94,0.3)]',
+      quote: 'text-lg text-green-300',
+      footer: 'border-t border-green-500',
+      hashtag: 'font-bold text-green-400',
+    },
+    dreamy: {
+      card: 'p-4 sm:p-8 bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50 dark:from-blue-900/20 dark:via-purple-900/20 dark:to-pink-900/20 rounded-2xl shadow-xl font-sans text-gray-700 dark:text-gray-200',
+      header: 'border-b border-purple-200 dark:border-purple-700',
+      name: 'text-5xl font-light text-transparent bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text',
+      group: 'text-base text-purple-500 dark:text-purple-400',
+      titleContainer: 'p-3 text-center rounded-2xl bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm border border-purple-200 dark:border-purple-600',
+      titleText: 'font-medium text-lg text-purple-700 dark:text-purple-300',
+      sectionTitle: 'text-purple-600 dark:text-purple-400',
+      tag: 'px-3 py-1 text-sm font-medium rounded-full bg-gradient-to-r from-blue-100 to-purple-100 dark:from-blue-800 dark:to-purple-800 text-purple-700 dark:text-purple-300',
+      quote: 'text-lg text-purple-600 dark:text-purple-400',
+      footer: 'border-t border-purple-200 dark:border-purple-700',
+      hashtag: 'font-medium text-purple-600 dark:text-purple-400',
+    },
+    retro: {
+      card: 'p-4 sm:p-8 bg-orange-50 dark:bg-orange-900/20 rounded-lg shadow-lg font-mono text-orange-900 dark:text-orange-100 border-2 border-orange-300 dark:border-orange-700',
+      header: 'border-b-4 border-orange-400 dark:border-orange-600',
+      name: 'text-5xl font-bold text-orange-700 dark:text-orange-300 tracking-wide',
+      group: 'text-base text-orange-600 dark:text-orange-400 uppercase',
+      titleContainer: 'p-3 text-center bg-orange-200 dark:bg-orange-800 border-2 border-orange-400 dark:border-orange-600 transform -rotate-2',
+      titleText: 'font-bold text-lg text-orange-800 dark:text-orange-200',
+      sectionTitle: 'text-orange-700 dark:text-orange-300 uppercase tracking-wide',
+      tag: 'px-3 py-1 text-sm font-bold bg-orange-200 dark:bg-orange-700 text-orange-800 dark:text-orange-200 border border-orange-400 dark:border-orange-500',
+      quote: 'text-lg text-orange-700 dark:text-orange-300 font-bold',
+      footer: 'border-t-4 border-orange-400 dark:border-orange-600',
+      hashtag: 'font-bold text-orange-700 dark:text-orange-300 uppercase',
+    },
+    minimal: {
+      card: 'p-4 sm:p-8 bg-white dark:bg-gray-900 rounded-none shadow-sm font-sans text-gray-900 dark:text-gray-100 border-l-4',
+      header: 'border-b border-gray-200 dark:border-gray-700',
+      name: 'text-5xl font-thin text-gray-900 dark:text-gray-100 tracking-wider',
+      group: 'text-base text-gray-500 dark:text-gray-400 font-light',
+      titleContainer: 'p-2 text-center bg-gray-100 dark:bg-gray-800',
+      titleText: 'font-normal text-lg text-gray-700 dark:text-gray-300',
+      sectionTitle: 'text-gray-500 dark:text-gray-400 font-light uppercase tracking-widest text-xs',
+      tag: 'px-2 py-1 text-xs font-normal bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400',
+      quote: 'text-lg text-gray-700 dark:text-gray-300 font-light italic',
+      footer: 'border-t border-gray-200 dark:border-gray-700',
+      hashtag: 'font-light text-gray-500 dark:text-gray-400',
     }
   };
 
@@ -79,14 +170,29 @@ export const ProfileCardPreview: React.FC<ProfileCardPreviewProps> = ({ profile,
     <div id="profile-card" className={`${s.card} aspect-[1.91/1] flex flex-col transition-all duration-300`}>
       {/* Header */}
       <header className={`flex items-start pb-2 sm:pb-4 ${s.header}`} style={accentStyle}>
+        {image && (
+          <div className="mr-4 flex-shrink-0">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={image}
+              alt={name}
+              className="w-20 h-20 object-cover rounded-lg shadow-md"
+              style={{ aspectRatio: '1/1' }}
+            />
+          </div>
+        )}
         <div className="flex-grow">
           <p className={`${s.group} text-sm sm:text-base`}>{group || ' '}</p>
           <h2 className={`${s.name} text-3xl sm:text-4xl md:text-5xl`}>{name || '推しの名前'}</h2>
         </div>
         {title && (
-          <div className={`${s.titleContainer} ml-2`}>
-            <p className={`${s.titleText} text-base sm:text-xl`} style={template === 'pop' ? {textShadow: '2px 2px 0 #000'} : {}}>{title}</p>
-            {template !== 'pop' && <p className="text-xs uppercase tracking-wider" style={accentTextStyle}>- Title -</p>}
+          <div className={`${s.titleContainer} ml-2 flex-shrink-0`} style={template === 'cool' ? accentStyle : {}}>
+            <p className={`${s.titleText} text-base sm:text-lg`}>{title}</p>
+            {template !== 'pop' && template !== 'neon' && (
+              <p className="text-xs uppercase tracking-wider mt-1 opacity-70" style={accentTextStyle}>
+                - Title -
+              </p>
+            )}
           </div>
         )}
       </header>

--- a/src/components/profile-maker/ProfileForm.tsx
+++ b/src/components/profile-maker/ProfileForm.tsx
@@ -56,6 +56,18 @@ export const ProfileForm: React.FC<ProfileFormProps> = ({ profile, setProfile })
     }));
   };
 
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const imageUrl = event.target?.result as string;
+        setProfile(prev => ({ ...prev, image: imageUrl }));
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   // Dummy handler for now
   const handleLikesChange = (newLikes: string[]) => {
     setProfile(prev => ({ ...prev, likes: newLikes }));
@@ -77,6 +89,39 @@ export const ProfileForm: React.FC<ProfileFormProps> = ({ profile, setProfile })
         value={profile.group}
         onChange={handleChange}
       />
+      
+      <div className="mb-6">
+        <label htmlFor="image" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+          推しの画像
+        </label>
+        <div className="space-y-3">
+          <input
+            type="file"
+            id="image"
+            accept="image/*"
+            onChange={handleImageUpload}
+            className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 dark:text-white shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100"
+          />
+          {profile.image && (
+            <div className="flex items-center space-x-3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={profile.image}
+                alt="推しの画像プレビュー"
+                className="w-16 h-16 object-cover rounded-lg border border-gray-300 dark:border-gray-600"
+              />
+              <button
+                type="button"
+                onClick={() => setProfile(prev => ({ ...prev, image: '' }))}
+                className="text-red-500 hover:text-red-700 text-sm font-medium"
+              >
+                画像を削除
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      
       <div className="mb-6">
           <label htmlFor="color" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
               担当・イメージカラー

--- a/src/components/profile-maker/ProfileForm.tsx
+++ b/src/components/profile-maker/ProfileForm.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { ProfileState } from "@/types";
+
+interface ProfileFormProps {
+  profile: ProfileState;
+  setProfile: React.Dispatch<React.SetStateAction<ProfileState>>;
+}
+
+// Reusable Input Component
+const FormInput = ({ label, name, value, onChange, placeholder, required = false, as = 'input' }: {
+  label: string;
+  name: keyof ProfileState;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  required?: boolean;
+  as?: 'input' | 'textarea';
+}) => (
+  <div className="mb-6">
+    <label htmlFor={name} className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+      {label} {required && <span className="text-red-500 ml-1">*</span>}
+    </label>
+    {as === 'input' ? (
+      <input
+        type="text"
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        required={required}
+        className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 dark:text-white shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+      />
+    ) : (
+      <textarea
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        rows={3}
+        className="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 dark:text-white shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"
+      />
+    )}
+  </div>
+);
+
+export const ProfileForm: React.FC<ProfileFormProps> = ({ profile, setProfile }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setProfile(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  // Dummy handler for now
+  const handleLikesChange = (newLikes: string[]) => {
+    setProfile(prev => ({ ...prev, likes: newLikes }));
+  };
+
+  return (
+    <form>
+      <h3 className="text-lg font-bold mb-4 text-indigo-600 dark:text-indigo-400 border-b pb-2">基本情報</h3>
+      <FormInput
+        label="推しの名前"
+        name="name"
+        value={profile.name}
+        onChange={handleChange}
+        required
+      />
+      <FormInput
+        label="推しの所属・グループ名など"
+        name="group"
+        value={profile.group}
+        onChange={handleChange}
+      />
+      <div className="mb-6">
+          <label htmlFor="color" className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">
+              担当・イメージカラー
+          </label>
+          <div className="flex items-center">
+              <input
+                  type="color"
+                  id="color"
+                  name="color"
+                  value={profile.color}
+                  onChange={handleChange}
+                  className="w-10 h-10 p-1 border-none rounded-lg cursor-pointer"
+              />
+              <span className="ml-3 p-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 dark:text-white text-sm">
+                  {profile.color}
+              </span>
+          </div>
+      </div>
+
+      <h3 className="text-lg font-bold mt-8 mb-4 text-indigo-600 dark:text-indigo-400 border-b pb-2">推しの"好き"を語る</h3>
+
+      <TagInput
+        label="推しの好きなところ（最大3つ）"
+        tags={profile.likes}
+        setTags={(newLikes) => setProfile(p => ({...p, likes: newLikes}))}
+        suggestions={['顔', '声', '性格', 'ダンス', '演技', '面白い', '優しい', '世界観']}
+        maxTags={3}
+      />
+
+      <FormInput
+        label="推しとの出会い（きっかけ）"
+        name="episode"
+        value={profile.episode}
+        onChange={handleChange}
+        placeholder="例：「〇〇という作品で一目惚れ」"
+      />
+      <FormInput
+        label="一番好きなビジュアル・衣装"
+        name="favoriteVisual"
+        value={profile.favoriteVisual}
+        onChange={handleChange}
+        placeholder="例：「〇〇のライブ衣装」"
+      />
+      <FormInput
+        label="一番好きなセリフ・歌詞"
+        name="favoriteQuote"
+        value={profile.favoriteQuote}
+        onChange={handleChange}
+        as="textarea"
+      />
+
+      <TagInput
+        label="推しを表すオリジナルタグ（最大3つ）"
+        tags={profile.customTags}
+        setTags={(newTags) => setProfile(p => ({...p, customTags: newTags}))}
+        placeholder="例: #存在が尊い"
+        maxTags={3}
+      />
+
+      <h3 className="text-lg font-bold mt-8 mb-4 text-indigo-600 dark:text-indigo-400 border-b pb-2">関係性について</h3>
+       <FormInput
+        label="推しコンビ・ペア名"
+        name="pairName"
+        value={profile.pairName}
+        onChange={handleChange}
+        placeholder="例：「〇〇と△△」"
+      />
+       <FormInput
+        label="そのコンビの好きなところ"
+        name="pairEpisode"
+        value={profile.pairEpisode}
+        onChange={handleChange}
+      />
+
+      <h3 className="text-lg font-bold mt-8 mb-4 text-indigo-600 dark:text-indigo-400 border-b pb-2">ステータス・記念日</h3>
+      <FormInput
+        label="ファン歴"
+        name="fanHistory"
+        value={profile.fanHistory}
+        onChange={handleChange}
+        placeholder="例: 約3年 / 2020年から"
+      />
+      <FormInput
+        label="推しへの称号"
+        name="title"
+        value={profile.title}
+        onChange={handleChange}
+        placeholder="例: 顔面国宝"
+      />
+    </form>
+  );
+};
+
+// --- Sub-components ---
+
+const TagInput = ({ label, tags, setTags, suggestions = [], placeholder = "タグを入力", maxTags }: {
+  label: string;
+  tags: string[];
+  setTags: (tags: string[]) => void;
+  suggestions?: string[];
+  placeholder?: string;
+  maxTags?: number;
+}) => {
+    const [inputValue, setInputValue] = useState('');
+
+    const addTag = (tag: string) => {
+        const newTag = tag.trim();
+        if (newTag && !tags.includes(newTag) && (!maxTags || tags.length < maxTags)) {
+            setTags([...tags, newTag]);
+        }
+        setInputValue('');
+    };
+
+    const removeTag = (tagToRemove: string) => {
+        setTags(tags.filter(tag => tag !== tagToRemove));
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            addTag(inputValue);
+        }
+    };
+
+    return (
+        <div className="mb-6">
+            <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{label}</label>
+            <div className="flex flex-wrap gap-2 mb-2 p-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-700 min-h-[44px]">
+                {tags.map(tag => (
+                    <span key={tag} className="flex items-center bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 text-sm font-medium px-2.5 py-1 rounded-full">
+                        {tag}
+                        <button onClick={() => removeTag(tag)} className="ml-2 text-indigo-500 hover:text-indigo-700 dark:hover:text-indigo-300">
+                            &times;
+                        </button>
+                    </span>
+                ))}
+                {(!maxTags || tags.length < maxTags) && (
+                    <input
+                        type="text"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        placeholder={tags.length === 0 ? placeholder : ''}
+                        className="flex-grow bg-transparent focus:outline-none text-gray-800 dark:text-white"
+                    />
+                )}
+            </div>
+            {suggestions.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                    {suggestions.map(suggestion => (
+                        <button
+                            key={suggestion}
+                            type="button"
+                            onClick={() => addTag(suggestion)}
+                            disabled={tags.includes(suggestion) || (maxTags != null && tags.length >= maxTags)}
+                            className="px-3 py-1 bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-200 text-sm rounded-full hover:bg-gray-300 dark:hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            + {suggestion}
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/profile-maker/ProfileForm.tsx
+++ b/src/components/profile-maker/ProfileForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { ProfileState } from "@/types";
 
 interface ProfileFormProps {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,10 @@
-export type Template = 'simple' | 'pop' | 'cool';
+export type Template = 'simple' | 'pop' | 'cool' | 'elegant' | 'kawaii' | 'vintage' | 'neon' | 'dreamy' | 'retro' | 'minimal';
 
 export type ProfileState = {
   name: string;
   group: string;
   color: string;
+  image: string;
   likes: string[];
   episode: string;
   favoriteVisual: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,16 @@
+export type Template = 'simple' | 'pop' | 'cool';
+
+export type ProfileState = {
+  name: string;
+  group: string;
+  color: string;
+  likes: string[];
+  episode: string;
+  favoriteVisual: string;
+  favoriteQuote: string;
+  customTags: string[];
+  pairName: string;
+  pairEpisode: string;
+  fanHistory: string;
+  title: string;
+};


### PR DESCRIPTION
This commit introduces a new feature: the "Oshikatsu Profile Maker," located at the `/profile-maker` route. This tool allows users to create and share stylish profile cards about their favorite characters or idols, aiming to drive user engagement and social media virality.

Key features implemented:
- A comprehensive input form with various field types, including text, color picker, and a custom tag-input component.
- Three distinct, switchable design templates: 'simple', 'pop', and 'cool'.
- Client-side image generation using `html2canvas` to create a PNG of the profile card.
- Functionality to download the generated image and share a pre-populated message on X (formerly Twitter).
- Responsive design to ensure a good user experience on both mobile and desktop devices.
- Centralized TypeScript types for better maintainability.